### PR TITLE
Added descriptive images to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Nowruz
 
+![GitHub Logo](/images/logo.png)
+![Nowrus image](https://upload.wikimedia.org/wikipedia/commons/5/59/White_house_haft_seen.jpg)
+
 This is a repository to **celebrate** _Nowruz_.
+
 
 
 Our Plan for Nowruz
@@ -12,5 +16,6 @@ Our Plan for Nowruz
 
 
 To know more about Nowruz, click [here](https://fa.wikipedia.org/wiki/%D9%86%D9%88%D8%B1%D9%88%D8%B2).
+
 
 Happy Nowruz


### PR DESCRIPTION
I thought that having an image of Nowruz will be a good change to Nowruz repository and many people can use that for their projects.

I added a link to wikipedia image according to suggestions from this [page](https://en.wikipedia.org/wiki/Nowruz).
This is an image of HaftSin. The image is from the following collection:
![image](https://user-images.githubusercontent.com/21107499/110492288-49edaf80-8107-11eb-9edd-a57bd049fa40.png)


Please review my changes and merge them in your project if they are useful.